### PR TITLE
[pt]feat: added missing translation

### DIFF
--- a/pt/frontend.php
+++ b/pt/frontend.php
@@ -23,6 +23,7 @@ return [
     'connecting' => 'Conectando...', //when connecting to the game server
     'signingIn' => 'Registrando-se',
     'loginFail' => 'Falha ao entrar!',
+    'loginFail2' => 'Não está logado! Você está jogando como um convidado chamado {name}.',
     'mapLoading' => 'Carregando mapa...',
 
     //Chat

--- a/pt/game.php
+++ b/pt/game.php
@@ -5,6 +5,8 @@ return [
     'live' => 'Online',
     'controls' => 'Controles',
     'gameSettings' => 'Configurações do jogo',
+    'skin' => 'Skin',           // (meaning block-skin texture), short version
+    'skin2' => 'Skin do bloco', // can be same, or longer than the previous line
     'appearance' => 'Aparência',
     'more' => '+',
     'gameControls' => 'Controles do jogo',
@@ -40,7 +42,7 @@ return [
     'appearSound' => 'Aparência & Som',
     'sound' => 'Som',
     'blockStyle' => 'Blocos',
-    'solidBlocks' => 'Cor sólida (sem pele)',
+    'solidBlocks' => 'Cor sólida (sem skin)',
     'invisibleBlocks' => 'Invisível',
     'monochrome' => 'Monocromático',
     'enableSE' => 'Habilitar efeitos sonoros',
@@ -115,6 +117,7 @@ return [
     'savePreset' => 'Salvar a predefinição',
     'customRooms'=> 'Salas personalizadas',
     'overflowRooms'=> 'Salas de overflow',
+    'guestRooms' => 'Salas de convidados',
     'spectateRooms'=> 'Salas de espectar',
     'gmode'=> 'Modo',
     'gmodeStandard'=> 'Padrão',
@@ -139,6 +142,8 @@ return [
     'ultra' => 'Ultra',
     '20TSD' => '20GTD',
     'PCmode' => 'Modo LT',
+    'bots' => 'Bots',
+    'rulesets' => 'Conjunto de regras',
     'all' => 'Tudo',
     'preset' => 'Predefinição',
     'save' => 'Salvar',
@@ -169,6 +174,7 @@ return [
     'randomizer' => 'Randomizador',
     'previews' => 'Previsões',
     'solidGarbage' => 'Lixo sólido',
+    'solidGarbageSpeed' => 'Velocidade lixo sólido',
     'solidAfterSecs' => 'Após',
     'lockDelay' => 'Atraso de travamento',
     'clearDelay' => 'Atraso de clareamento',
@@ -194,5 +200,5 @@ return [
 
     'expand' => 'Expandir',
 
-    'translationBy' => 'P1iko, Ovie, kaikecarlos',
+    'translationBy' => 'P1iko, Ovie, kaikecarlos, Flavin27',
 ];

--- a/pt/supporter.php
+++ b/pt/supporter.php
@@ -2,6 +2,7 @@
 
 return [
     'donate' => 'Doar', //menu item, short
+    'supportUs' => 'Nos apoie', //menu item, short
     'descr' => 'Suporte o Jstris e habilite recompensas de Apoiador mandando uma doação.',
     'supportJstris' => 'Suporte Jstris',
     'supportDesc1' => 'Se você aprecia o jogo, por favor considere uma doação para ajudar a cobrir os gastos do servidor e o desenvolvimento que está a vir.',

--- a/pt/web.php
+++ b/pt/web.php
@@ -41,6 +41,7 @@ return [
     'leastBlocks' => 'Menor quantia de blocos',
     'myTimes' => 'Meus tempos',
     'perfectFinesse' => 'Fineza 0',
+    'mostGames' => 'Mais jogos',
     
     /* Replay */
     'load' => 'Carregar',


### PR DESCRIPTION
* Added missing translations for all elements.
* Updated the translation for "skin" from "pele" to "skin" itself. Note that in Brazilian Portuguese, the term "skin" is commonly used in the context of games, referring to the visual appearance of characters or items.
* Added my name to the "TranslationBy" section.